### PR TITLE
Add viewport tag, version CSS to force cache invalidation

### DIFF
--- a/site/static/style.css
+++ b/site/static/style.css
@@ -104,24 +104,18 @@
         padding: 10px 15px;
         text-align: left;
     }
-    
-    h2 {
-        font-size: 3rem;
-    }
-
-    .btn {
-        width: 100%;
-    }
 
     .locationButton {
         flex: 0 1 calc(100%); /* Adjust the width to 33.33% minus margin */
-        margin: 20px 40px;
+        margin: 10px 20px;
         gap: 0px;
-        height: 388px;
-        font-size: 3rem;
+        font-size: 2rem;
     }
 
-    #knock_name_input {
-        font-size: 2rem;
+    /* Embiggening for the location button */
+
+    .btn {
+        width: 100%;
+        font-size: 1.25rem;
     }
 }

--- a/site/static/style.css
+++ b/site/static/style.css
@@ -105,14 +105,16 @@
         text-align: left;
     }
 
+    /* Embiggening for the location button */
+
     .locationButton {
-        flex: 0 1 calc(100%); /* Adjust the width to 33.33% minus margin */
+        flex: 0 1 calc(100%);
         margin: 10px 20px;
         gap: 0px;
         font-size: 2rem;
     }
 
-    /* Embiggening for the location button */
+    /* Embiggening for the dialogue button */
 
     .btn {
         width: 100%;

--- a/site/templates/home.tmpl
+++ b/site/templates/home.tmpl
@@ -2,11 +2,12 @@
 <html>
 <head>
     <link rel="stylesheet" href="https://themeswitcher.csh.rit.edu/api/get" media="screen">
-    <link rel="stylesheet" type="text/css" href="/static/style.css">
+    <link rel="stylesheet" type="text/css" href="/static/style.css?v=1"> <!--Apply arbitrary version tag to CSS to force cache resolution. Increment this number when you change this file-->
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <script defer src="/static/home.js"></script>
+    <script defer src="/static/home.js?v=1"></script> <!--Apply arbitrary version tag to JS to force cache resolution. Increment this number when you change this file-->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
         <nav class="navbar navbar-expand-lg navbar-dark bg-primary">


### PR DESCRIPTION
The viewport tag is some magic that will automagically scale your website for mobile.

![image](https://github.com/user-attachments/assets/245aaeeb-c72d-4dd7-a36c-312721645f8e)
